### PR TITLE
add support for OS with CMAKE version 3.12 and below

### DIFF
--- a/bf_sde.py
+++ b/bf_sde.py
@@ -267,6 +267,7 @@ def install_switch_bsp():
     install_bsp_deps()
     
     import subprocess
+    import re
     out = subprocess.check_output("cmake --version", shell=True)
     res = re.search(r'version\s*([\d.]+)', str(out)).group(1)
     if res >= '3.13':

--- a/bf_sde.py
+++ b/bf_sde.py
@@ -265,9 +265,18 @@ def install_switch_bsp():
             os.environ['BSP_INSTALL']))
 
     install_bsp_deps()
-    cmake_cmd = 'cmake -DCMAKE_INSTALL_PREFIX={}'.format(get_env_var('SDE_INSTALL'))
-    cmake_cmd += ' -B ' + aps_bsp_installation_file
-    cmake_cmd += ' -S ' + aps_bsp_installation_file
+    
+    import subprocess
+    out = subprocess.check_output("cmake --version", shell=True)
+    res = re.search(r'version\s*([\d.]+)', str(out)).group(1)
+    if res >= '3.13':
+        cmake_cmd = 'cmake -DCMAKE_INSTALL_PREFIX={}'.format(get_env_var('SDE_INSTALL'))
+        cmake_cmd += ' -B ' + aps_bsp_installation_file
+        cmake_cmd += ' -S ' + aps_bsp_installation_file
+    else:
+        cmake_cmd = 'cmake -DCMAKE_INSTALL_PREFIX={}'.format(get_env_var('SDE_INSTALL'))
+        cmake_cmd += ' -B' + aps_bsp_installation_file
+        cmake_cmd += ' -H' + aps_bsp_installation_file
     execute_cmd(cmake_cmd)
     os.system("make -C {0}".format(aps_bsp_installation_file))
     os.system("make -C {0} install".format(aps_bsp_installation_file))


### PR DESCRIPTION
Ubuntu 18.04 only comes with CMAKE 3.10.2, by default (see https://launchpad.net/ubuntu/bionic/+source/cmake) unless the user manually builds and installs newer CMAKE versions.
Thus, BSP installation will fail with the existing script as the script currently assumes certain parameters that are only available in CMAKE version 3.13 and above.
This PR adds support for older CMAKE versions by adding conditions to check the CMAKE version before executing the corresponding CMAKE command.
See: https://stackoverflow.com/questions/18826789/cmake-output-build-directory
